### PR TITLE
Include your previous changes, indicating Rails 3.0 compatibility

### DIFF
--- a/README
+++ b/README
@@ -44,6 +44,12 @@ http://www.crockford.com/javascript/jsmin.html
 
 == Updates
 
+March '10
+* Fix thread safety issue.
+* JSMin compatibility fix for Ruby 1.9.1 – Fixnum#ord
+* Rails >= 2.3 test compatibility
+* Rails 3 deprecations – change RAILS_ROOT to Rails.root, change RAILS_ENV to Rails.env, move tasks to lib dir
+
 November '08:
 * Rails 2.2 compatibility fixes
 * No more mucking with internal Rails functions, which means:


### PR DESCRIPTION
It took me a bit of time to find figure out if asset_packager was Rails 3.0 compatible. I found your blog post (http://synthesis.sbecker.net/articles/2010/03/21/asset-packager-rails-3-ruby-1-9-compatible) and updated the README file to reflect those changes.
