### PR TITLE
Issue in asset-packager with rails 3.0.5 due to the unsafe html string

### DIFF
--- a/lib/synthesis/asset_package_helper.rb
+++ b/lib/synthesis/asset_package_helper.rb
@@ -21,7 +21,8 @@ module Synthesis
         AssetPackage.targets_from_sources("javascripts", sources) : 
         AssetPackage.sources_from_targets("javascripts", sources))
         
-      sources.collect {|source| javascript_include_tag(source, options) }.join("\n")
+      #sources.collect {|source| javascript_include_tag(source, options) }.join("\n")
+      javascript_include_tag(sources, options)
     end
 
     def stylesheet_link_merged(*sources)
@@ -32,7 +33,8 @@ module Synthesis
         AssetPackage.targets_from_sources("stylesheets", sources) : 
         AssetPackage.sources_from_targets("stylesheets", sources))
 
-      sources.collect { |source| stylesheet_link_tag(source, options) }.join("\n")    
+      #sources.collect { |source| stylesheet_link_tag(source, options) }.join("\n")    
+      stylesheet_link_tag(sources, options)
     end
 
   end


### PR DESCRIPTION
I am using  asset-packager with rails 3.0.5 , had a strange problem. It started printing the js include statements as a text (unsafe html) instead of a html. 

It turns out there is a problem in this line of asset_packager_helper.rb

``` ruby
sources.collect {|source| javascript_include_tag(source, options) }.join("\n")
#and 
sources.collect { |source| stylesheet_link_tag(source, options) }.join("\n")    
```

javascript_include_tag itself returns the safe html input, and by joining them we are producing the unsafe string. To avoid that we can directly call the javascript_include_tag with sources array

``` ruby
javascript_include_tag(sources, options)
#and
stylesheet_link_tag(sources, options)
```

thanks
